### PR TITLE
[Feat]: Member API 구현 및 awsS3 서비스 책임 분리화

### DIFF
--- a/src/main/java/com/example/gotogetherbe/auth/controller/AuthController.java
+++ b/src/main/java/com/example/gotogetherbe/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.example.gotogetherbe.auth.dto.ReissueDto;
 import com.example.gotogetherbe.auth.dto.SignInDto;
 import com.example.gotogetherbe.auth.dto.SignUpDto;
 import com.example.gotogetherbe.auth.service.AuthService;
+import com.example.gotogetherbe.global.util.jwt.dto.TokenDto;
 import com.example.gotogetherbe.global.util.mail.dto.SendMailRequest;
 import com.example.gotogetherbe.global.util.mail.dto.VerifyMailRequest;
 import com.example.gotogetherbe.global.util.mail.service.MailService;
@@ -35,7 +36,7 @@ public class AuthController {
   }
 
   @PostMapping("/signIn")
-  public ResponseEntity<?> signInUser(@RequestBody SignInDto request){
+  public ResponseEntity<TokenDto> signInUser(@RequestBody SignInDto request){
     return ResponseEntity.ok(authService.signIn(request));
   }
   @PostMapping("/logout")

--- a/src/main/java/com/example/gotogetherbe/auth/controller/AuthController.java
+++ b/src/main/java/com/example/gotogetherbe/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.example.gotogetherbe.auth.dto.SignUpDto;
 import com.example.gotogetherbe.auth.service.AuthService;
 import com.example.gotogetherbe.global.util.jwt.dto.TokenDto;
 import com.example.gotogetherbe.global.util.mail.dto.SendMailRequest;
+import com.example.gotogetherbe.global.util.mail.dto.SendMailResponse;
 import com.example.gotogetherbe.global.util.mail.dto.VerifyMailRequest;
 import com.example.gotogetherbe.global.util.mail.service.MailService;
 import jakarta.validation.Valid;
@@ -30,7 +31,7 @@ public class AuthController {
   private final MailService mailService;
 
   @PostMapping("/signUp")
-  public ResponseEntity<?> signUpUser(@RequestPart("request") SignUpDto request,
+  public ResponseEntity<SignUpDto> signUpUser(@RequestPart("request") SignUpDto request,
       @RequestPart(name = "image", required = false) MultipartFile image){
     return ResponseEntity.status(HttpStatus.CREATED).body(authService.signUp(request,image));
   }
@@ -46,11 +47,11 @@ public class AuthController {
   }
 
   @PostMapping("/reissue")
-  public ResponseEntity<?> reissueToken(@Valid @RequestBody ReissueDto request){
+  public ResponseEntity<TokenDto> reissueToken(@Valid @RequestBody ReissueDto request){
     return ResponseEntity.ok(authService.reissue(request));
   }
   @PostMapping("/mail/certification")
-  public ResponseEntity<?> sendCertificationMail(@RequestBody SendMailRequest request){
+  public ResponseEntity<SendMailResponse> sendCertificationMail(@RequestBody SendMailRequest request){
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(mailService.generateAndDispatchAuthCode(request.getEmail()));
   }

--- a/src/main/java/com/example/gotogetherbe/global/util/aws/service/AwsS3Service.java
+++ b/src/main/java/com/example/gotogetherbe/global/util/aws/service/AwsS3Service.java
@@ -72,7 +72,7 @@ public class AwsS3Service {
    * @param multipartFile 업로드할 파일
    * @param fileName      파일 이름
    */
-  private void uploadToS3(MultipartFile multipartFile, String fileName) {
+  public void uploadToS3(MultipartFile multipartFile, String fileName) {
     try (InputStream inputStream = multipartFile.getInputStream()) {
       amazonS3.putObject(new PutObjectRequest(bucketName, fileName, inputStream,
           getObjectMetadata(multipartFile))
@@ -92,19 +92,28 @@ public class AwsS3Service {
     }
   }
 
-  private String getUrl(String fileName) {
+  public String getUrl(String fileName) {
     return amazonS3.getUrl(bucketName, fileName).toString();
   }
 
 
-  private ObjectMetadata getObjectMetadata(MultipartFile multipartFile) {
+  public ObjectMetadata getObjectMetadata(MultipartFile multipartFile) {
     ObjectMetadata objectMetadata = new ObjectMetadata();
     objectMetadata.setContentType(multipartFile.getContentType());
     objectMetadata.setContentLength(multipartFile.getSize());
     return objectMetadata;
   }
 
-  private String generateFileName(MultipartFile multipartFile) {
+  public String generateFileName(MultipartFile multipartFile) {
     return UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
+  }
+
+  // URL 을 사용하여 파일을 삭제하는 메서드
+  public void deleteFileUsingUrl(String fileUrl) {
+    String fileName = extractFileNameFromUrl(fileUrl);
+    deleteFile(fileName); // 기존에 작성한 deleteFile 메서드를 재사용
+  }
+  public String extractFileNameFromUrl(String fileUrl) {
+    return fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
   }
 }

--- a/src/main/java/com/example/gotogetherbe/member/controller/MemberController.java
+++ b/src/main/java/com/example/gotogetherbe/member/controller/MemberController.java
@@ -1,0 +1,43 @@
+package com.example.gotogetherbe.member.controller;
+
+
+import com.example.gotogetherbe.auth.config.LoginUser;
+import com.example.gotogetherbe.member.dto.MemberRequest;
+import com.example.gotogetherbe.member.dto.MemberResponse;
+import com.example.gotogetherbe.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("api/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+  private final MemberService memberService;
+
+  @GetMapping("/myProfile")
+  public ResponseEntity<MemberResponse> getMyProfile(@LoginUser String username){
+    return ResponseEntity.ok(memberService.getMyProfileInfo(username));
+  }
+
+  @PutMapping("/myProfile")
+  public ResponseEntity<MemberResponse> updateMyProfile(@Valid @RequestBody MemberRequest request,
+      @LoginUser String username,
+      MultipartFile profileImage){
+    return ResponseEntity.ok(memberService.updateMyProfileInfo(request,username, profileImage));
+  }
+
+  @GetMapping("/profile/")
+  public ResponseEntity<MemberResponse> getProfile(@RequestParam("memberId") Long id){
+    return ResponseEntity.ok(memberService.getMemberInfo(id));
+  }
+
+}

--- a/src/main/java/com/example/gotogetherbe/member/dto/MemberRequest.java
+++ b/src/main/java/com/example/gotogetherbe/member/dto/MemberRequest.java
@@ -1,0 +1,70 @@
+package com.example.gotogetherbe.member.dto;
+
+import com.example.gotogetherbe.member.entitiy.Member;
+import com.example.gotogetherbe.member.entitiy.type.MemberGender;
+import com.example.gotogetherbe.member.entitiy.type.MemberMbti;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberRequest {
+
+  @Email
+  private String email;
+
+  @NotBlank
+  private String password;
+
+  @NotBlank
+  private String name;
+
+  @NotBlank
+  private String nickname;
+
+  @NotBlank
+  private String phoneNumber;
+
+  @NotBlank
+  private String address;
+
+  @NotNull
+  private Integer age;
+
+  @NotNull
+  private MemberGender gender;
+
+  private MemberMbti mbti;
+
+  private String instagramId;
+
+  private String description;
+
+  private String profileImageUrl;
+
+
+  public void updateMemberInfoToEntity(Member member,String encodedPasswordEncoder
+      ,String profileImageUrl) {
+    member.setPassword(encodedPasswordEncoder);
+    member.setNickname(this.nickname);
+    member.setPhoneNumber(this.phoneNumber);
+    member.setAddress(this.address);
+    member.setAge(this.age);
+    member.setGender(this.gender);
+    member.setMbti(this.mbti);
+    member.setInstagramId(this.instagramId);
+    member.setDescription(this.description);
+    member.setProfileImageUrl(profileImageUrl);
+
+  }
+
+}

--- a/src/main/java/com/example/gotogetherbe/member/dto/MemberResponse.java
+++ b/src/main/java/com/example/gotogetherbe/member/dto/MemberResponse.java
@@ -1,0 +1,63 @@
+package com.example.gotogetherbe.member.dto;
+
+import com.example.gotogetherbe.member.entitiy.Member;
+import com.example.gotogetherbe.member.entitiy.type.MemberGender;
+import com.example.gotogetherbe.member.entitiy.type.MemberMbti;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberResponse {
+
+  private Long id;
+
+  private String email;
+
+  private String password;
+
+  private String name;
+
+  private String nickname;
+
+  private String phoneNumber;
+
+  private String address;
+
+  private Integer age;
+
+  private MemberGender gender;
+
+  private MemberMbti mbti;
+
+  private String instagramId;
+
+  private String description;
+
+  private String profileImageUrl;
+
+  public static MemberResponse fromEntity(Member member, boolean includeSensitiveInfo) {
+    MemberResponse.MemberResponseBuilder builder = MemberResponse.builder()
+        .id(member.getId())
+        .email(member.getEmail())
+        .nickname(member.getNickname())
+        .phoneNumber(member.getPhoneNumber())
+        .address(member.getAddress())
+        .gender(member.getGender())
+        .age(member.getAge())
+        .mbti(member.getMbti())
+        .instagramId(member.getInstagramId())
+        .description(member.getDescription())
+        .profileImageUrl(member.getProfileImageUrl());
+
+    if (includeSensitiveInfo) {
+      builder.password(member.getPassword()); // Sensitive info
+    }
+
+    return builder.build();
+  }
+}

--- a/src/main/java/com/example/gotogetherbe/member/service/MemberService.java
+++ b/src/main/java/com/example/gotogetherbe/member/service/MemberService.java
@@ -1,0 +1,89 @@
+package com.example.gotogetherbe.member.service;
+
+import static com.example.gotogetherbe.global.exception.type.ErrorCode.PROFILE_IMAGE_UPLOAD_ERROR;
+import static com.example.gotogetherbe.global.exception.type.ErrorCode.USER_NOT_FOUND;
+
+import com.example.gotogetherbe.global.exception.GlobalException;
+import com.example.gotogetherbe.global.util.aws.service.AwsS3Service;
+import com.example.gotogetherbe.member.dto.MemberRequest;
+import com.example.gotogetherbe.member.dto.MemberResponse;
+import com.example.gotogetherbe.member.entitiy.Member;
+import com.example.gotogetherbe.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+  private final MemberRepository memberRepository;
+  private final AwsS3Service awsS3Service;
+  private final PasswordEncoder passwordEncoder;
+
+  @Transactional
+  public MemberResponse getMyProfileInfo(String username){
+
+    return MemberResponse.fromEntity(memberRepository.findByEmail(username)
+        .orElseThrow(() -> new GlobalException(USER_NOT_FOUND)), true);
+  }
+
+  @Transactional
+  public MemberResponse getMemberInfo(Long id){
+    return MemberResponse.fromEntity(memberRepository.findById(id)
+        .orElseThrow(() -> new GlobalException(USER_NOT_FOUND)), false);
+  }
+
+  @Transactional
+  public MemberResponse updateMyProfileInfo(MemberRequest memberDto, String username,
+      MultipartFile profileImage){
+
+    Member member = memberRepository.findByEmail(username)
+        .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+
+    String encodedPasswordEncoder = passwordEncoder.encode(memberDto.getPassword());
+    String profileImageUrl = member.getProfileImageUrl();
+
+    if (profileImage != null && !profileImage.isEmpty()) {
+      // 기존 이미지가 있다면 삭제
+      if(profileImageUrl != null && !profileImageUrl.isEmpty()){
+          awsS3Service.deleteFileUsingUrl(profileImageUrl);
+      }
+      // 새 이미지 업로드 시도
+      try {
+        profileImageUrl = uploadProfileImage(profileImage);
+      } catch (Exception e) { // 이미지 업로드 중 오류 발생 시 예외 처리
+        throw new GlobalException(PROFILE_IMAGE_UPLOAD_ERROR);
+      }
+    }
+
+    // MemberDto 로 부터 값을 받아와 Member 객체의 상태 변경
+    memberDto.updateMemberInfoToEntity(member,encodedPasswordEncoder,profileImageUrl);
+
+    return MemberResponse.fromEntity(member,true);
+
+  }
+
+  /**
+   * 프로필 이미지를 AWS S3에 업로드하고 그에 대한 URL 을 반환.
+   *
+   * @param multipartFile 업로드할 이미지 파일
+   * @return 업로드된 이미지의 S3 URL
+   */
+  private String uploadProfileImage(MultipartFile multipartFile) {
+    log.info("[uploadProfileImage] start");
+
+    String fileName = awsS3Service.generateFileName(multipartFile);
+    awsS3Service.uploadToS3(multipartFile, fileName);
+
+    return awsS3Service.getUrl(fileName);
+  }
+
+
+
+
+}

--- a/src/main/java/com/example/gotogetherbe/member/service/MemberService.java
+++ b/src/main/java/com/example/gotogetherbe/member/service/MemberService.java
@@ -25,14 +25,14 @@ public class MemberService {
   private final AwsS3Service awsS3Service;
   private final PasswordEncoder passwordEncoder;
 
-  @Transactional
+  @Transactional(readOnly = true)
   public MemberResponse getMyProfileInfo(String username){
 
     return MemberResponse.fromEntity(memberRepository.findByEmail(username)
         .orElseThrow(() -> new GlobalException(USER_NOT_FOUND)), true);
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   public MemberResponse getMemberInfo(Long id){
     return MemberResponse.fromEntity(memberRepository.findById(id)
         .orElseThrow(() -> new GlobalException(USER_NOT_FOUND)), false);

--- a/src/test/java/com/example/gotogetherbe/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/gotogetherbe/member/service/MemberServiceTest.java
@@ -1,0 +1,124 @@
+package com.example.gotogetherbe.member.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.example.gotogetherbe.global.exception.GlobalException;
+import com.example.gotogetherbe.global.exception.type.ErrorCode;
+import com.example.gotogetherbe.global.util.aws.service.AwsS3Service;
+import com.example.gotogetherbe.member.dto.MemberRequest;
+import com.example.gotogetherbe.member.dto.MemberResponse;
+import com.example.gotogetherbe.member.entitiy.Member;
+import com.example.gotogetherbe.member.entitiy.type.MemberGender;
+import com.example.gotogetherbe.member.entitiy.type.MemberRoleType;
+import com.example.gotogetherbe.member.repository.MemberRepository;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+class MemberServiceTest {
+
+  @InjectMocks
+  private MemberService memberService;
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @Mock
+  private AwsS3Service awsS3Service;
+
+  private Member member;
+
+  @BeforeEach
+  void setup() {
+    member = Member.builder()
+        .id(1L)
+        .email("test@test.com")
+        .password("12345")
+        .nickname("김철수")
+        .phoneNumber("010-1234-6789")
+        .address("서울")
+        .age(20)
+        .gender(MemberGender.FEMALE)
+        .roleType(MemberRoleType.USER)
+        .build();
+  }
+
+  @Test
+  @DisplayName("회원 정보 조회 성공")
+  void success_GetMyProfileInfo() {
+    // given
+    given(memberRepository.findByEmail("test@test.com"))
+        .willReturn(Optional.of(member));
+    //when
+    MemberResponse myProfileResponse = memberService.getMyProfileInfo("test@test.com");
+
+    //then
+    Assertions.assertEquals(myProfileResponse.getEmail(), member.getEmail());
+  }
+
+  @Test
+  @DisplayName("회원 정보 조회 실패")
+  void fail_GetMyProfileInfo() {
+    //given
+    given(memberRepository.findByEmail("test@test.com"))
+        .willReturn(Optional.empty());
+    //when
+    GlobalException globalException = assertThrows(GlobalException.class,
+        () -> memberService.getMyProfileInfo("test@test.com"));
+
+    //then
+    Assertions.assertEquals(ErrorCode.USER_NOT_FOUND, globalException.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("회원 정보 수정 성공 - 이미지 수정 X")
+  void success_updateInfo() {
+    //given
+    MemberRequest updateRequest = MemberRequest.builder()
+        .nickname("김민재")
+        .phoneNumber("010-5555-6666")
+        .password("1234512")
+        .build();
+
+    given(memberRepository.findByEmail(anyString()))
+        .willReturn(Optional.of(member));
+    given(passwordEncoder.encode(updateRequest.getPassword())).willReturn("암호화된비밀번호");
+
+    //when
+    MemberResponse myProfileResponse = memberService.updateMyProfileInfo(updateRequest,
+        "test@test.com", null);
+    //then
+    assertEquals(myProfileResponse.getNickname(), updateRequest.getNickname());
+    assertEquals(myProfileResponse.getNickname(), updateRequest.getNickname());
+    assertEquals(myProfileResponse.getPhoneNumber(), updateRequest.getPhoneNumber());
+    assertEquals(myProfileResponse.getEmail(), member.getEmail());
+
+    verify(memberRepository, times(1)).findByEmail("test@test.com");
+    verify(passwordEncoder, times(1)).encode("1234512");
+    verify(awsS3Service, never()).deleteFileUsingUrl(anyString()); // 이미지 삭제 메소드가 호출되지 않았음을 검증
+    verify(awsS3Service, never()).uploadToS3(any(),any()); // 이미지 업로드 메소드가 호출되지 않았음을 검증
+  }
+
+  // 예를 들어, member 객체의 nickname, phoneNumber, password가 updateRequest의 값과 일치하는지 확인하는 등의 검증이 필요할 수 있습니다.
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
# **AS-IS**
 -  AwsS3Service에 post, member 이미지 업로드 기능까지 있어, AwsS3Service 역할이 모호함.

# **TO-BE**
- MemberService, PostService에 이미지 업로드 로직을 구현하고 필요한 파일 업로드 처리만 Awss3Service에 위임
- 회원 자신의 정보 조회
- 다른 회원 정보 조회
- 회원 자신의 정보 수정 
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 


 