### PR TITLE
[Feat] : MainSchedule CRUD 구현

### DIFF
--- a/src/main/java/com/example/gotogetherbe/global/exception/type/ErrorCode.java
+++ b/src/main/java/com/example/gotogetherbe/global/exception/type/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
   NOT_SAME_ACCOMPANY_MEMBER(HttpStatus.BAD_REQUEST, "같은 동행에 참여한 회원이 아닙니다."),
 
 
+
   /**
    * 401 Unauthorized
    */
@@ -62,6 +63,7 @@ public enum ErrorCode {
    */
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자가 없습니다."),
   ACCOMPANY_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "동행 요청을 찾을 수 없습니다."),
+  MAIN_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "주요 일정을 찾을 수 없습니다."),
   
   /**
    * 406 Not Acceptable
@@ -78,6 +80,7 @@ public enum ErrorCode {
   MEMBER_POST_INCORRECT(HttpStatus.CONFLICT, "회원의 게시글이 아닙니다."),
   ALREADY_PARTICIPANT_MEMBER(HttpStatus.CONFLICT, "이미 참여중인 회원입니다."),
   DUPLICATE_ACCOMPANY_REQUEST(HttpStatus.CONFLICT, "동일한 요청이 존재합니다."),
+  MEMBER_AND_MAIN_SCHEDULE_INCORRECT(HttpStatus.CONFLICT, "회원이 작성한 주요일정이 아닙니다."),
 
   DUPLICATE_REVIEW(HttpStatus.CONFLICT, "이미 리뷰를 작성하셨습니다."),
 

--- a/src/main/java/com/example/gotogetherbe/mainschedule/controller/MainScheduleController.java
+++ b/src/main/java/com/example/gotogetherbe/mainschedule/controller/MainScheduleController.java
@@ -1,0 +1,52 @@
+package com.example.gotogetherbe.mainschedule.controller;
+
+import com.example.gotogetherbe.auth.config.LoginUser;
+import com.example.gotogetherbe.mainschedule.dto.MainScheduleDto;
+import com.example.gotogetherbe.mainschedule.dto.MainScheduleRequest;
+import com.example.gotogetherbe.mainschedule.service.MainScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/main-schedule")
+public class MainScheduleController {
+
+  private final MainScheduleService mainScheduleService;
+
+  @PostMapping("/{postId}")
+  public ResponseEntity<MainScheduleDto> createMainSchedule(@LoginUser String email,
+      @PathVariable Long postId,
+      @RequestBody MainScheduleRequest request
+      ) {
+    return ResponseEntity.ok(mainScheduleService.createMainSchedule(email, postId, request));
+  }
+
+  @GetMapping("/{postId}")
+  public ResponseEntity<?> getMainSchedule(@PathVariable Long postId) {
+    return ResponseEntity.ok(mainScheduleService.getMainSchedule(postId));
+  }
+
+  @PutMapping("/{mainScheduleId}")
+  public ResponseEntity<MainScheduleDto> updateMainSchedule(@LoginUser String email,
+      @PathVariable Long mainScheduleId,
+      @RequestBody MainScheduleRequest request
+  ) {
+    return ResponseEntity.ok(mainScheduleService.updateMainSchedule(email, mainScheduleId, request));
+  }
+
+  @DeleteMapping("/{mainScheduleId}")
+  public ResponseEntity<MainScheduleDto> deleteMainSchedule(@LoginUser String email,
+      @PathVariable Long mainScheduleId
+  ) {
+    return ResponseEntity.ok(mainScheduleService.deleteMainSchedule(email, mainScheduleId));
+  }
+}

--- a/src/main/java/com/example/gotogetherbe/mainschedule/dto/MainScheduleDto.java
+++ b/src/main/java/com/example/gotogetherbe/mainschedule/dto/MainScheduleDto.java
@@ -1,0 +1,29 @@
+package com.example.gotogetherbe.mainschedule.dto;
+
+import com.example.gotogetherbe.mainschedule.entity.MainSchedule;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MainScheduleDto {
+
+  private Long id;
+  private Long postId;
+  private LocalDate scheduleDate;
+  private String content;
+
+  public static MainScheduleDto from(MainSchedule mainSchedule) {
+    return MainScheduleDto.builder()
+        .id(mainSchedule.getId())
+        .postId(mainSchedule.getPost().getId())
+        .scheduleDate(mainSchedule.getScheduleDate())
+        .content(mainSchedule.getContent())
+        .build();
+  }
+}

--- a/src/main/java/com/example/gotogetherbe/mainschedule/dto/MainScheduleRequest.java
+++ b/src/main/java/com/example/gotogetherbe/mainschedule/dto/MainScheduleRequest.java
@@ -1,0 +1,18 @@
+package com.example.gotogetherbe.mainschedule.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MainScheduleRequest {
+  @NotNull(message = "주요일정의 날짜를 입력해주세요.")
+  private LocalDate scheduleDate;
+
+  @NotNull(message = "내용을 입력해주세요.")
+  private String content;
+}

--- a/src/main/java/com/example/gotogetherbe/mainschedule/entity/MainSchedule.java
+++ b/src/main/java/com/example/gotogetherbe/mainschedule/entity/MainSchedule.java
@@ -1,0 +1,44 @@
+package com.example.gotogetherbe.mainschedule.entity;
+
+import com.example.gotogetherbe.chat.entity.ChatRoom;
+import com.example.gotogetherbe.global.entity.BaseEntity;
+import com.example.gotogetherbe.post.entity.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MainSchedule extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id")
+  private Post post;
+
+  @Column(nullable = false)
+  private LocalDate scheduleDate;
+
+  @Column(nullable = false)
+  private String content;
+
+}

--- a/src/main/java/com/example/gotogetherbe/mainschedule/repository/MainScheduleRepository.java
+++ b/src/main/java/com/example/gotogetherbe/mainschedule/repository/MainScheduleRepository.java
@@ -1,0 +1,12 @@
+package com.example.gotogetherbe.mainschedule.repository;
+
+import com.example.gotogetherbe.mainschedule.entity.MainSchedule;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MainScheduleRepository extends JpaRepository<MainSchedule, Long> {
+
+  List<MainSchedule> findAllByPostId(Long postId);
+}

--- a/src/main/java/com/example/gotogetherbe/mainschedule/service/MainScheduleService.java
+++ b/src/main/java/com/example/gotogetherbe/mainschedule/service/MainScheduleService.java
@@ -1,0 +1,126 @@
+package com.example.gotogetherbe.mainschedule.service;
+
+import static com.example.gotogetherbe.global.exception.type.ErrorCode.POST_NOT_FOUND;
+import static com.example.gotogetherbe.global.exception.type.ErrorCode.USER_NOT_FOUND;
+
+import com.example.gotogetherbe.global.exception.GlobalException;
+import com.example.gotogetherbe.global.exception.type.ErrorCode;
+import com.example.gotogetherbe.mainschedule.dto.MainScheduleDto;
+import com.example.gotogetherbe.mainschedule.dto.MainScheduleRequest;
+import com.example.gotogetherbe.mainschedule.entity.MainSchedule;
+import com.example.gotogetherbe.mainschedule.repository.MainScheduleRepository;
+import com.example.gotogetherbe.member.entitiy.Member;
+import com.example.gotogetherbe.member.repository.MemberRepository;
+import com.example.gotogetherbe.post.entity.Post;
+import com.example.gotogetherbe.post.repository.PostRepository;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MainScheduleService {
+
+  private final MemberRepository memberRepository;
+  private final PostRepository postRepository;
+  private final MainScheduleRepository mainScheduleRepository;
+
+  /**
+   * 주요일정 생성
+   *
+   * @param email      주요일정을 생성하는 회원의 이메일
+   * @param postId     주요일정을 생성할 게시글ID
+   * @param request    생성할 주요일정 정보
+   * @return 생성된 주요일정의 정보를 포함한 MainScheduleDto 객체
+   */
+  @Transactional
+  public MainScheduleDto createMainSchedule(String email, Long postId, MainScheduleRequest request) {
+    Member member = getMemberOrThrow(email);
+    Post post = getPostOrThrow(postId);
+
+    // 게시글 작성자만 주요일정 추가 가능
+    if (!Objects.equals(member.getId(), post.getMember().getId())) {
+      throw new GlobalException(ErrorCode.MEMBER_POST_INCORRECT);
+    }
+
+    MainSchedule mainSchedule = mainScheduleRepository.save(MainSchedule.builder()
+            .post(post)
+            .scheduleDate(request.getScheduleDate())
+            .content(request.getContent())
+            .build());
+
+    return MainScheduleDto.from(mainSchedule);
+  }
+
+  /**
+   * 주요일정 목록 조회
+   *
+   * @param postId     주요일정을 조회할 게시글ID
+   * @return 주요일정의 정보를 포함한 MainScheduleDto 목록
+   */
+  @Transactional(readOnly = true)
+  public List<MainScheduleDto> getMainSchedule(Long postId) {
+    return mainScheduleRepository.findAllByPostId(postId).stream().map(MainScheduleDto::from).collect(Collectors.toList());
+  }
+
+  /**
+   * 주요일정 수정
+   *
+   * @param email      주요일정을 수정하는 회원의 이메일
+   * @param mainScheduleId     수정할 주요일정ID
+   * @param request    수정할 주요일정 정보
+   * @return 수정된 주요일정의 정보를 포함한 MainScheduleDto 객체
+   */
+  @Transactional
+  public MainScheduleDto updateMainSchedule(String email, Long mainScheduleId, MainScheduleRequest request) {
+    Member member = getMemberOrThrow(email);
+    MainSchedule mainSchedule = mainScheduleRepository.findById(mainScheduleId)
+        .orElseThrow(() -> new GlobalException(ErrorCode.MAIN_SCHEDULE_NOT_FOUND));
+
+    if (!Objects.equals(member.getId(), mainSchedule.getPost().getMember().getId())) {
+      throw new GlobalException(ErrorCode.MEMBER_AND_MAIN_SCHEDULE_INCORRECT);
+    }
+
+    mainSchedule.setScheduleDate(request.getScheduleDate());
+    mainSchedule.setContent(request.getContent());
+
+    MainSchedule updatedMainSchedule = mainScheduleRepository.save(mainSchedule);
+
+    return MainScheduleDto.from(updatedMainSchedule);
+  }
+
+  /**
+   * 주요일정 삭제
+   *
+   * @param email      주요일정을 삭제하는 회원의 이메일
+   * @param mainScheduleId     삭제할 주요일정ID
+   * @return 삭제한 주요일정의 정보를 포함한 MainScheduleDto 객체
+   */
+  @Transactional
+  public MainScheduleDto deleteMainSchedule(String email, Long mainScheduleId) {
+    Member member = getMemberOrThrow(email);
+    MainSchedule mainSchedule = mainScheduleRepository.findById(mainScheduleId)
+        .orElseThrow(() -> new GlobalException(ErrorCode.MAIN_SCHEDULE_NOT_FOUND));
+
+    if (!Objects.equals(member.getId(), mainSchedule.getPost().getMember().getId())) {
+      throw new GlobalException(ErrorCode.MEMBER_AND_MAIN_SCHEDULE_INCORRECT);
+    }
+
+    mainScheduleRepository.delete(mainSchedule);
+
+    return MainScheduleDto.from(mainSchedule);
+  }
+
+  private Member getMemberOrThrow(String email) {
+    return memberRepository.findByEmail(email)
+        .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+  }
+
+  private Post getPostOrThrow(Long postId) {
+    return postRepository.findById(postId)
+        .orElseThrow(() -> new GlobalException(POST_NOT_FOUND));
+  }
+}


### PR DESCRIPTION
## 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
#### 1. Main Schedule Create
- email, postId, request를 입력받아 주요일정 생성
- 게시글 작성자만 생성 가능하도록 구현

#### 2. Main Schedule Read
- postId를 받아 해당 게시글에 해당하는 주요일정 목록 조회
- 로그인 필요 없이 조회 가능

#### 3. Main Schedule Update
- email, postId, request를 입력받아 주요일정 수정
- 게시글 작성자만 수정 가능하도록 구현

#### 4. Main Schedule Delete
- email, postId 를 입력받아 주요일정 삭제
- 게시글 작성자만 삭제 가능하도록 구현

**TO-BE**
- Test Code 작성

## 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [] 테스트 코드
- [] API 테스트 

## 리뷰어들에게 요청사항
- 주요일정 생성,수정,삭제를 게시글 작성자만 가능하도록 일단 구현했는데, 이대로 유지할지, 동행에 참여한 인원들 다 생성,수정,삭제가 가능할지 의견 내주시면 감사하겠습니다! 