### PR TITLE
[Feat] : accompany request 수정 및 요청 취소 구현 

### DIFF
--- a/src/main/java/com/example/gotogetherbe/accompany/request/controller/AccompanyRequestController.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/request/controller/AccompanyRequestController.java
@@ -30,6 +30,12 @@ public class AccompanyRequestController {
             .sendAccompanyRequest(username, accompanyRequestSendDto));
     }
 
+    @PostMapping("/cancel/{requestId}")
+    public ResponseEntity<String> cancelAccompanyRequest( @PathVariable Long requestId) {
+        accompanyRequestService.cancelAccompanyRequest(requestId);
+        return ResponseEntity.ok().body("Accompany request canceled successfully.");
+    }
+
     @GetMapping("/send")
     public ResponseEntity<List<AccompanyRequestDto>> sentAccompanyRequest(@LoginUser String username) {
         return ResponseEntity.ok(accompanyRequestService.getSentAccompanyRequests(username));

--- a/src/main/java/com/example/gotogetherbe/accompany/request/controller/AccompanyRequestController.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/request/controller/AccompanyRequestController.java
@@ -33,7 +33,7 @@ public class AccompanyRequestController {
     @PostMapping("/cancel/{requestId}")
     public ResponseEntity<String> cancelAccompanyRequest( @PathVariable Long requestId) {
         accompanyRequestService.cancelAccompanyRequest(requestId);
-        return ResponseEntity.ok().body("Accompany request canceled successfully.");
+        return ResponseEntity.ok("Accompany request canceled successfully.");
     }
 
     @GetMapping("/send")
@@ -50,16 +50,14 @@ public class AccompanyRequestController {
     public ResponseEntity<AccompanyRequestDto> approveAccompanyRequest(
         @LoginUser String username, @PathVariable Long requestId
     ) {
-        return ResponseEntity.ok()
-            .body(accompanyRequestService.approveAccompanyRequest(username, requestId));
+        return ResponseEntity.ok(accompanyRequestService.approveAccompanyRequest(username, requestId));
     }
 
     @PostMapping("/reject/{requestId}")
     public ResponseEntity<AccompanyRequestDto> rejectAccompanyRequest(
         @LoginUser String username, @PathVariable Long requestId
     ) {
-        return ResponseEntity.ok()
-            .body(accompanyRequestService.rejectAccompanyRequest(username, requestId));
+        return ResponseEntity.ok(accompanyRequestService.rejectAccompanyRequest(username, requestId));
     }
 
 }

--- a/src/main/java/com/example/gotogetherbe/accompany/request/controller/AccompanyRequestController.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/request/controller/AccompanyRequestController.java
@@ -1,8 +1,10 @@
 package com.example.gotogetherbe.accompany.request.controller;
 
+import com.example.gotogetherbe.accompany.request.dto.AccompanyRequestDto;
 import com.example.gotogetherbe.accompany.request.dto.AccompanyRequestSendDto;
 import com.example.gotogetherbe.accompany.request.service.AccompanyRequestService;
 import com.example.gotogetherbe.auth.config.LoginUser;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,38 +22,35 @@ public class AccompanyRequestController {
     private final AccompanyRequestService accompanyRequestService;
 
     @PostMapping("/send")
-    public ResponseEntity<?> sendAccompanyRequest(
+    public ResponseEntity<AccompanyRequestDto> sendAccompanyRequest(
         @LoginUser String username,
         @RequestBody AccompanyRequestSendDto accompanyRequestSendDto
     ) {
-        return ResponseEntity.ok()
-            .body(accompanyRequestService.sendAccompanyRequest(username, accompanyRequestSendDto));
+        return ResponseEntity.ok(accompanyRequestService
+            .sendAccompanyRequest(username, accompanyRequestSendDto));
     }
 
     @GetMapping("/send")
-    public ResponseEntity<?> sentAccompanyRequest(@LoginUser String username) {
-        return ResponseEntity.ok().body(accompanyRequestService.getSentAccompanyRequests(username));
+    public ResponseEntity<List<AccompanyRequestDto>> sentAccompanyRequest(@LoginUser String username) {
+        return ResponseEntity.ok(accompanyRequestService.getSentAccompanyRequests(username));
     }
 
     @GetMapping("/receive")
-    public ResponseEntity<?> receivedAccompanyRequest(@LoginUser String username) {
-        return ResponseEntity.ok()
-            .body(accompanyRequestService.getReceivedAccompanyRequests(username));
+    public ResponseEntity<List<AccompanyRequestDto>> receivedAccompanyRequest(@LoginUser String username) {
+        return ResponseEntity.ok(accompanyRequestService.getReceivedAccompanyRequests(username));
     }
 
     @PostMapping("/approve/{requestId}")
-    public ResponseEntity<?> approveAccompanyRequest(
-        @LoginUser String username,
-        @PathVariable Long requestId
+    public ResponseEntity<AccompanyRequestDto> approveAccompanyRequest(
+        @LoginUser String username, @PathVariable Long requestId
     ) {
         return ResponseEntity.ok()
             .body(accompanyRequestService.approveAccompanyRequest(username, requestId));
     }
 
     @PostMapping("/reject/{requestId}")
-    public ResponseEntity<?> rejectAccompanyRequest(
-        @LoginUser String username,
-        @PathVariable Long requestId
+    public ResponseEntity<AccompanyRequestDto> rejectAccompanyRequest(
+        @LoginUser String username, @PathVariable Long requestId
     ) {
         return ResponseEntity.ok()
             .body(accompanyRequestService.rejectAccompanyRequest(username, requestId));

--- a/src/main/java/com/example/gotogetherbe/accompany/request/entity/AccompanyRequest.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/request/entity/AccompanyRequest.java
@@ -19,13 +19,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -54,5 +52,9 @@ public class AccompanyRequest {
 
     @CreatedDate
     private LocalDateTime createdAt;
+
+    public void updateRequestStatus(RequestStatus requestStatus) {
+        this.requestStatus = requestStatus;
+    }
 
 }

--- a/src/main/java/com/example/gotogetherbe/accompany/request/repository/AccompanyRequestRepository.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/request/repository/AccompanyRequestRepository.java
@@ -8,11 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AccompanyRequestRepository extends JpaRepository<AccompanyRequest, Long> {
 
-    List<AccompanyRequest> findAllByRequestMember_Email(String email);
+    List<AccompanyRequest> findAllByRequestMemberIdOrderByCreatedAtDesc(Long requestMemberId);
 
-    List<AccompanyRequest> findAllByRequestedMember_Email(String email);
+    List<AccompanyRequest> findAllByRequestedMemberIdOrderByCreatedAtDesc(Long requestedMemberId);
 
-    boolean existsByRequestMemberAndRequestedMemberAndPost(
-        Member requestMember, Member requestedMember, Post post);
+    boolean existsByRequestedMember_IdAndRequestedMember_IdAndPost_Id(
+        Long requestMemberId, Long requestedMemberId, Long postId);
 
 }

--- a/src/main/java/com/example/gotogetherbe/accompany/request/repository/AccompanyRequestRepository.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/request/repository/AccompanyRequestRepository.java
@@ -1,8 +1,6 @@
 package com.example.gotogetherbe.accompany.request.repository;
 
 import com.example.gotogetherbe.accompany.request.entity.AccompanyRequest;
-import com.example.gotogetherbe.member.entitiy.Member;
-import com.example.gotogetherbe.post.entity.Post;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/example/gotogetherbe/accompany/request/service/AccompanyRequestService.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/request/service/AccompanyRequestService.java
@@ -94,6 +94,18 @@ public class AccompanyRequestService {
         return AccompanyRequestDto.from(accompanyRequestRepository.save(request));
     }
 
+    /**
+     * 동행 요청 취소
+     * @param requestId 요청 ID
+     */
+    @Transactional
+    public void cancelAccompanyRequest(Long requestId) {
+        AccompanyRequest accompanyRequest = accompanyRequestRepository.findById(requestId)
+            .orElseThrow(() -> new GlobalException(ACCOMPANY_REQUEST_NOT_FOUND));
+
+        accompanyRequestRepository.delete(accompanyRequest);
+    }
+
     private Member getMemberByEmail(String email) {
         return memberRepository.findByEmail(email)
             .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
@@ -125,4 +137,5 @@ public class AccompanyRequestService {
 
         return accompanyRequest;
     }
+
 }

--- a/src/main/java/com/example/gotogetherbe/post/entity/Post.java
+++ b/src/main/java/com/example/gotogetherbe/post/entity/Post.java
@@ -38,78 +38,82 @@ import lombok.Setter;
 @AllArgsConstructor
 public class Post extends BaseEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id")
-  private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
-  @Column(nullable = false)
-  @Enumerated(EnumType.STRING)
-  @Builder.Default
-  private PostRecruitmentStatus recruitmentStatus = PostRecruitmentStatus.RECRUITING;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private PostRecruitmentStatus recruitmentStatus = PostRecruitmentStatus.RECRUITING;
 
-  @Column(nullable = false, length = 20)
-  @Enumerated(EnumType.STRING)
-  private TravelCountryType travelCountry;
+    @Column(nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private TravelCountryType travelCountry;
 
-  @Column(nullable = false, length = 20)
-  @Enumerated(EnumType.STRING)
-  private TravelCityType travelCity;
+    @Column(nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private TravelCityType travelCity;
 
-  @Column(nullable = false)
-  private LocalDateTime startDate;
+    @Column(nullable = false)
+    private LocalDateTime startDate;
 
-  @Column(nullable = false)
-  private LocalDateTime endDate;
+    @Column(nullable = false)
+    private LocalDateTime endDate;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 10)
-  private PostGenderType gender;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private PostGenderType gender;
 
-  @Column(nullable = false)
-  private Integer minimumAge;
+    @Column(nullable = false)
+    private Integer minimumAge;
 
-  @Column(nullable = false)
-  private Integer maximumAge;
+    @Column(nullable = false)
+    private Integer maximumAge;
 
-  @Column(nullable = false)
-  private Integer recruitsPeople;
+    @Column(nullable = false)
+    private Integer recruitsPeople;
 
-  @Builder.Default
-  @Column(nullable = false)
-  private Integer currentPeople = 0;
+    @Builder.Default
+    @Column(nullable = false)
+    private Integer currentPeople = 0;
 
-  @Column
-  private Integer estimatedTravelExpense;
+    @Column
+    private Integer estimatedTravelExpense;
 
-  @Enumerated(EnumType.STRING)
-  @Column(length = 10)
-  private PostCategory category;
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private PostCategory category;
 
-  @Column(nullable = false, length = 20)
-  private String title;
+    @Column(nullable = false, length = 20)
+    private String title;
 
-  @Column(nullable = false, columnDefinition = "TEXT")
-  private String content;
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
 
-  @Column(nullable = false)
-  @Builder.Default
-  Boolean chatRoomExists = false;
+    @Column(nullable = false)
+    @Builder.Default
+    Boolean chatRoomExists = false;
 
-  @Builder.Default
-  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<PostImage> images = new ArrayList<>();
+    @Builder.Default
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostImage> images = new ArrayList<>();
 
-  public void addImage(PostImage image){
-    this.images.add(image);
-    image.mappingPost(this);
-  }
-  public void removeImage(PostImage image){
-    this.images.remove(image);
-  }
+    public void addImage(PostImage image) {
+        this.images.add(image);
+        image.mappingPost(this);
+    }
 
+    public void removeImage(PostImage image) {
+        this.images.remove(image);
+    }
+
+    public void updateCurrentPeople() {
+        this.currentPeople++;
+    }
 
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**

**TO-BE**
- responseEntity 와일드카드 제거
- setter -> update 메서드, setter를 제거하고 변경이 필요한 부분을 따로 entity에 메서드를 만들어서 업데이트 할 수 있도록 함 
 -> 캡슐화 유지, 객체의 상태 변경에 필요한 로직을 한 곳에 집중시켜 유지보수에 용이하도록 함 
- 동행 요청 취소 기능 구현 

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 