### PR TITLE
[Feat] OAuth 인증 인가 구현

### DIFF
--- a/src/main/java/com/example/gotogetherbe/auth/controller/AuthController.java
+++ b/src/main/java/com/example/gotogetherbe/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.example.gotogetherbe.auth.dto.SignUpDto;
 import com.example.gotogetherbe.auth.service.AuthService;
 import com.example.gotogetherbe.global.util.jwt.dto.TokenDto;
 import com.example.gotogetherbe.global.util.mail.dto.SendMailRequest;
+import com.example.gotogetherbe.global.util.mail.dto.SendMailResponse;
 import com.example.gotogetherbe.global.util.mail.dto.VerifyMailRequest;
 import com.example.gotogetherbe.global.util.mail.service.MailService;
 import jakarta.validation.Valid;
@@ -30,7 +31,7 @@ public class AuthController {
   private final MailService mailService;
 
   @PostMapping("/signUp")
-  public ResponseEntity<?> signUpUser(@RequestPart("request") SignUpDto request,
+  public ResponseEntity<SignUpDto> signUpUser(@RequestPart("request") SignUpDto request,
       @RequestPart(name = "image", required = false) MultipartFile image){
     return ResponseEntity.status(HttpStatus.CREATED).body(authService.signUp(request,image));
   }
@@ -46,11 +47,11 @@ public class AuthController {
   }
 
   @PostMapping("/reissue")
-  public ResponseEntity<?> reissueToken(@Valid @RequestBody ReissueDto request){
+  public ResponseEntity<TokenDto> reissueToken(@Valid @RequestBody ReissueDto request){
     return ResponseEntity.ok(authService.reissue(request));
   }
   @PostMapping("/mail/certification")
-  public ResponseEntity<?> sendCertificationMail(@RequestBody SendMailRequest request){
+  public ResponseEntity<SendMailResponse> sendCertificationMail(@RequestBody SendMailRequest request){
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(mailService.generateAndDispatchAuthCode(request.getEmail()));
   }

--- a/src/main/java/com/example/gotogetherbe/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/gotogetherbe/global/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,70 @@
+package com.example.gotogetherbe.global.oauth;
+
+import com.example.gotogetherbe.member.entitiy.Member;
+import com.example.gotogetherbe.member.service.MemberService;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+  private final MemberService memberService;
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+    OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
+
+    // OAuth2UserService 를 사용하여 OAuth2User 정보를 가져온다.
+    OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
+
+    // 클라이언트 등록 ID와 사용자 이름 속성을 가져온다.
+    String registrationId = userRequest.getClientRegistration().getRegistrationId();
+    String userNameAttributeName = userRequest.getClientRegistration()
+        .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+
+    // OAuth2UserService 를 사용하여 가져온 OAuth2User 정보로 OAuth2Attribute 객체를 만든다.
+    OAuth2Attribute oAuth2Attribute =
+        OAuth2Attribute.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+    // OAuth2Attribute 의 속성값들을 Map 으로 반환 받는다.
+    Map<String, Object> memberAttribute = oAuth2Attribute.convertToMap();
+
+    // 사용자 email(또는 id) 정보를 가져온다.
+    String email = (String) memberAttribute.get("email");
+
+    // 이메일로 가입된 회원인지 조회한다.
+    Optional<Member> findMember = memberService.findByEmail(email);
+
+    if (findMember.isEmpty()) {
+      // 회원이 존재하지 않을경우, memberAttribute 의 exist 값을 false 로 넣어준다.
+      memberAttribute.put("exist", false);
+      // 회원의 권한(회원이 존재하지 않으므로 기본권한인 ROLE_USER 를 넣어준다), 회원속성, 속성이름을 이용해 DefaultOAuth2User 객체를 생성해 반환한다.
+      return new DefaultOAuth2User(
+          Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+          memberAttribute, "email");
+    }
+
+    // 회원이 존재할경우, memberAttribute 의 exist 값을 true 로 넣어준다.
+    memberAttribute.put("exist", true);
+
+    // 회원의 권한과, 회원속성, 속성이름을 이용해 DefaultOAuth2User 객체를 생성해 반환한다.
+    return new DefaultOAuth2User(
+        Collections.singleton(new SimpleGrantedAuthority(findMember.get().getRoleType().toString())),
+        memberAttribute, "email");
+  }
+}

--- a/src/main/java/com/example/gotogetherbe/global/oauth/MyAuthenticationFailureHandler.java
+++ b/src/main/java/com/example/gotogetherbe/global/oauth/MyAuthenticationFailureHandler.java
@@ -1,0 +1,23 @@
+package com.example.gotogetherbe.global.oauth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class MyAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException, ServletException {
+
+    // 인증 실패시 메인 페이지로 이동
+    response.sendRedirect("http://localhost:8080/");
+  }
+}

--- a/src/main/java/com/example/gotogetherbe/global/oauth/MyAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/gotogetherbe/global/oauth/MyAuthenticationSuccessHandler.java
@@ -1,0 +1,72 @@
+package com.example.gotogetherbe.global.oauth;
+
+import com.example.gotogetherbe.global.util.jwt.TokenProvider;
+import com.example.gotogetherbe.global.util.jwt.dto.TokenDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+  private final TokenProvider tokenProvider;
+  public void onAuthenticationSuccess(HttpServletRequest request,
+      HttpServletResponse response, Authentication authentication) throws IOException,
+      ServletException {
+
+    // OAuth2User 로 캐스팅하여 인증된 사용자 정보를 가져온다.
+    OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+    String email = oAuth2User.getAttribute("email");
+
+    String provider = oAuth2User.getAttribute("provider");
+
+    // CustomOAuth2UserService 에서 셋팅한 로그인한 회원 존재 여부를 가져온다.
+    boolean isExist = Boolean.TRUE.equals(oAuth2User.getAttribute("exist"));
+
+    String role = oAuth2User.getAuthorities().stream().
+        findFirst()
+        .orElseThrow(IllegalAccessError::new)
+        .getAuthority();
+
+    if (isExist) {
+      // 회원이 존재하면 jwt token 발행을 시작한다.
+      TokenDto token = tokenProvider.generateToken(email, role);
+      log.info("jwtToken = {}", token.getAccessToken());
+
+      // accessToken 을 쿼리스트링에 담는 url 을 만들어준다.
+      String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/loginSuccess")
+          .queryParam("accessToken", token.getAccessToken())
+          .build()
+          .encode(StandardCharsets.UTF_8)
+          .toUriString();
+      log.info("redirect 준비");
+
+      // 로그인 확인 페이지로 리다이렉트 시킨다.
+      getRedirectStrategy().sendRedirect(request, response, targetUrl);
+
+
+    } else {
+
+      String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/loginSuccess")
+          .queryParam("email", (String) oAuth2User.getAttribute("email"))
+          .queryParam("provider", provider)
+          .build()
+          .encode(StandardCharsets.UTF_8)
+          .toUriString();
+
+      getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+  }
+}

--- a/src/main/java/com/example/gotogetherbe/global/oauth/OAuth2Attribute.java
+++ b/src/main/java/com/example/gotogetherbe/global/oauth/OAuth2Attribute.java
@@ -1,0 +1,60 @@
+package com.example.gotogetherbe.global.oauth;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Builder(access = AccessLevel.PRIVATE) // Builder 메서드를 외부에서 사용하지 않으므로, Private 제어자로 지정
+@Getter
+public class OAuth2Attribute {
+
+  private Map<String, Object> attributes; // 사용자 속성 정보를 담는 Map
+  private String attributeKey; // 사용자 속성의 키 값
+  private String email; // 이메일 정보
+  private String nickname; // 닉네임 정보
+  private String provider; // 제공자 정보
+
+
+  // 서비스에 따라 OAuth2Attribute 객체를 생성하는 메서드
+  static OAuth2Attribute of(String provider, String attributeKey,
+      Map<String, Object> attributes) {
+    if (provider.equals("kakao")) {
+      return ofKakao(provider, "email", attributes);
+    }
+    throw new RuntimeException();
+  }
+
+  /**
+   *
+   * Kakao 로그인일 경우 사용하는 메서드, 필요한 사용자 정보가
+   * kakaoAccount -> kakaoProfile 두번 감싸져 있어서,
+   *   두번 get() 메서드를 이용해 사용자 정보를 담고있는 Map을 꺼내야한다.
+   */
+  private static OAuth2Attribute ofKakao(String provider, String attributeKey,
+      Map<String, Object> attributes) {
+    Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+    Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
+
+    return OAuth2Attribute.builder()
+        .email((String) kakaoAccount.get("email"))
+        .provider(provider)
+        .attributes(kakaoAccount)
+        .attributeKey(attributeKey)
+        .build();
+  }
+
+  // OAuth2User 객체에 넣어주기 위해서 Map 으로 값들을 반환해준다.
+  Map<String, Object> convertToMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("id", attributeKey);
+    map.put("key", attributeKey);
+    map.put("email", email);
+    map.put("provider", provider);
+
+    return map;
+  }
+}

--- a/src/main/java/com/example/gotogetherbe/member/service/MemberService.java
+++ b/src/main/java/com/example/gotogetherbe/member/service/MemberService.java
@@ -25,14 +25,14 @@ public class MemberService {
   private final AwsS3Service awsS3Service;
   private final PasswordEncoder passwordEncoder;
 
-  @Transactional
+  @Transactional(readOnly = true)
   public MemberResponse getMyProfileInfo(String username){
 
     return MemberResponse.fromEntity(memberRepository.findByEmail(username)
         .orElseThrow(() -> new GlobalException(USER_NOT_FOUND)), true);
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   public MemberResponse getMemberInfo(Long id){
     return MemberResponse.fromEntity(memberRepository.findById(id)
         .orElseThrow(() -> new GlobalException(USER_NOT_FOUND)), false);


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
# **AS-IS**
- OAuth2 인증 성공 후, 사용자 정보 처리 및 회원 존재 여부 확인 없음.

# **TO-BE**
- OAuth2 인증을 통해 가져온 사용자 정보를 기반으로, 시스템에 사용자가 이미 존재하는지 확인하는 
   로직을 추가
 
- 사용자가 시스템에 존재하지 않는 경우, 사용자의 정보를 바탕으로 시스템에 자동으로 가입시키는 기능을 구현

- 이 경우, 사용자 속성 정보에 'exist' 키를 추가하여, 이 값이 false일 경우 새로운 사용자로 간주하고, true인 경우 기존 사용자로 처리

- OAuth2 인증 성공 시, 사용자 정보 추출 및 JWT 토큰 발급. 회원 여부에 따라 다른 리다이렉트 처리 구현.
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [] 테스트 코드
- [] API 테스트 


 