### PR TITLE
[Feat] : Notification Event Publish

### DIFF
--- a/src/main/java/com/example/gotogetherbe/accompany/request/service/AccompanyStatusService.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/request/service/AccompanyStatusService.java
@@ -11,6 +11,7 @@ import static com.example.gotogetherbe.global.exception.type.ErrorCode.USER_NOT_
 import static com.example.gotogetherbe.notification.type.NotificationType.ACCOMPANY_REQUEST;
 import static com.example.gotogetherbe.notification.type.NotificationType.ACCOMPANY_REQUEST_APPROVAL;
 import static com.example.gotogetherbe.notification.type.NotificationType.ACCOMPANY_REQUEST_REJECT;
+import static com.example.gotogetherbe.post.entity.type.PostRecruitmentStatus.*;
 
 import com.example.gotogetherbe.accompany.request.dto.AccompanyStatusDto;
 import com.example.gotogetherbe.accompany.request.entity.Accompany;
@@ -20,6 +21,7 @@ import com.example.gotogetherbe.member.entitiy.Member;
 import com.example.gotogetherbe.member.repository.MemberRepository;
 import com.example.gotogetherbe.notification.service.EventPublishService;
 import com.example.gotogetherbe.post.entity.Post;
+import com.example.gotogetherbe.post.entity.type.PostRecruitmentStatus;
 import com.example.gotogetherbe.post.repository.PostRepository;
 import java.util.List;
 import java.util.Objects;
@@ -98,6 +100,7 @@ public class AccompanyStatusService {
 
         Post post = getOrElseThrow(accompany.getPost().getId());
         post.updateCurrentPeople();
+        isRecruitmentFull(post);
         postRepository.save(post);
 
         Member requestMember = getMemberById(accompany.getRequestMember().getId());
@@ -166,6 +169,12 @@ public class AccompanyStatusService {
             requestMemberId, postId)
         ) {
             throw new GlobalException(DUPLICATE_ACCOMPANY_REQUEST);
+        }
+    }
+
+    private static void isRecruitmentFull(Post post) {
+        if (Objects.equals(post.getRecruitsPeople(), post.getCurrentPeople())) {
+            post.updateRecruitmentStatus(RECRUITMENT_COMPLETED);
         }
     }
 

--- a/src/main/java/com/example/gotogetherbe/accompany/request/service/AccompanyStatusService.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/request/service/AccompanyStatusService.java
@@ -8,7 +8,9 @@ import static com.example.gotogetherbe.global.exception.type.ErrorCode.DUPLICATE
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.POST_NOT_FOUND;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.USER_MISMATCH;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.USER_NOT_FOUND;
-import static com.example.gotogetherbe.notification.type.NotificationType.*;
+import static com.example.gotogetherbe.notification.type.NotificationType.ACCOMPANY_REQUEST;
+import static com.example.gotogetherbe.notification.type.NotificationType.ACCOMPANY_REQUEST_APPROVAL;
+import static com.example.gotogetherbe.notification.type.NotificationType.ACCOMPANY_REQUEST_REJECT;
 
 import com.example.gotogetherbe.accompany.request.dto.AccompanyStatusDto;
 import com.example.gotogetherbe.accompany.request.entity.Accompany;
@@ -16,17 +18,13 @@ import com.example.gotogetherbe.accompany.request.repository.AccompanyRepository
 import com.example.gotogetherbe.global.exception.GlobalException;
 import com.example.gotogetherbe.member.entitiy.Member;
 import com.example.gotogetherbe.member.repository.MemberRepository;
-import com.example.gotogetherbe.notification.dto.NotificationInfoDto;
 import com.example.gotogetherbe.notification.service.EventPublishService;
-import com.example.gotogetherbe.notification.type.NotificationStatus;
-import com.example.gotogetherbe.notification.type.NotificationType;
 import com.example.gotogetherbe.post.entity.Post;
 import com.example.gotogetherbe.post.repository.PostRepository;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/example/gotogetherbe/accompany/request/service/AccompanyStatusService.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/request/service/AccompanyStatusService.java
@@ -11,7 +11,7 @@ import static com.example.gotogetherbe.global.exception.type.ErrorCode.USER_NOT_
 import static com.example.gotogetherbe.notification.type.NotificationType.ACCOMPANY_REQUEST;
 import static com.example.gotogetherbe.notification.type.NotificationType.ACCOMPANY_REQUEST_APPROVAL;
 import static com.example.gotogetherbe.notification.type.NotificationType.ACCOMPANY_REQUEST_REJECT;
-import static com.example.gotogetherbe.post.entity.type.PostRecruitmentStatus.*;
+import static com.example.gotogetherbe.post.entity.type.PostRecruitmentStatus.RECRUITMENT_COMPLETED;
 
 import com.example.gotogetherbe.accompany.request.dto.AccompanyStatusDto;
 import com.example.gotogetherbe.accompany.request.entity.Accompany;
@@ -21,7 +21,6 @@ import com.example.gotogetherbe.member.entitiy.Member;
 import com.example.gotogetherbe.member.repository.MemberRepository;
 import com.example.gotogetherbe.notification.service.EventPublishService;
 import com.example.gotogetherbe.post.entity.Post;
-import com.example.gotogetherbe.post.entity.type.PostRecruitmentStatus;
 import com.example.gotogetherbe.post.repository.PostRepository;
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/com/example/gotogetherbe/accompany/review/service/ReviewService.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/review/service/ReviewService.java
@@ -6,6 +6,7 @@ import static com.example.gotogetherbe.global.exception.type.ErrorCode.MEMBER_AS
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.POST_NOT_FOUND;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.UNCOMPLETED_ACCOMPANY;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.USER_NOT_FOUND;
+import static com.example.gotogetherbe.notification.type.NotificationType.*;
 import static com.example.gotogetherbe.post.entity.type.PostRecruitmentStatus.COMPLETED;
 
 import com.example.gotogetherbe.accompany.request.entity.Accompany;
@@ -21,6 +22,8 @@ import com.example.gotogetherbe.accompany.review.repository.ReviewRepository;
 import com.example.gotogetherbe.global.exception.GlobalException;
 import com.example.gotogetherbe.member.entitiy.Member;
 import com.example.gotogetherbe.member.repository.MemberRepository;
+import com.example.gotogetherbe.notification.service.EventPublishService;
+import com.example.gotogetherbe.notification.type.NotificationType;
 import com.example.gotogetherbe.post.entity.Post;
 import com.example.gotogetherbe.post.repository.PostRepository;
 import java.util.ArrayList;
@@ -43,6 +46,7 @@ public class ReviewService {
     private final MemberAssessmentRepository memberAssessmentRepository;
     private final MemberAssessmentService memberAssessmentService;
     private final AccompanyRepository accompanyRepository;
+    private final EventPublishService eventPublishService;
 
     /**
      * 동행 참여자 조회
@@ -81,6 +85,10 @@ public class ReviewService {
         List<Review> savedReviews = reviewRepository.saveAll(reviews);
 
         memberAssessmentService.updateMemberAssessment(savedReviews);
+
+        for (Review review : savedReviews) {
+            eventPublishService.publishEvent(post.getId(), review.getTargetMember(), NEW_REVIEW);
+        }
 
         return savedReviews.stream().map(ReviewDto::from).toList();
     }

--- a/src/main/java/com/example/gotogetherbe/accompany/review/service/ReviewService.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/review/service/ReviewService.java
@@ -6,7 +6,7 @@ import static com.example.gotogetherbe.global.exception.type.ErrorCode.MEMBER_AS
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.POST_NOT_FOUND;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.UNCOMPLETED_ACCOMPANY;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.USER_NOT_FOUND;
-import static com.example.gotogetherbe.notification.type.NotificationType.*;
+import static com.example.gotogetherbe.notification.type.NotificationType.NEW_REVIEW;
 import static com.example.gotogetherbe.post.entity.type.PostRecruitmentStatus.COMPLETED;
 
 import com.example.gotogetherbe.accompany.request.entity.Accompany;
@@ -23,7 +23,6 @@ import com.example.gotogetherbe.global.exception.GlobalException;
 import com.example.gotogetherbe.member.entitiy.Member;
 import com.example.gotogetherbe.member.repository.MemberRepository;
 import com.example.gotogetherbe.notification.service.EventPublishService;
-import com.example.gotogetherbe.notification.type.NotificationType;
 import com.example.gotogetherbe.post.entity.Post;
 import com.example.gotogetherbe.post.repository.PostRepository;
 import java.util.ArrayList;

--- a/src/main/java/com/example/gotogetherbe/accompany/review/service/ReviewService.java
+++ b/src/main/java/com/example/gotogetherbe/accompany/review/service/ReviewService.java
@@ -61,8 +61,7 @@ public class ReviewService {
         verifyCompletedStatus(post);
         verifyDuplicationReview(post, reviewer);
 
-        List<Accompany> accompanies = accompanyRepository.findAllByPostIdAndStatus(postId,
-            PARTICIPATING);
+        List<Accompany> accompanies = accompanyRepository.findAllByPostIdAndStatus(postId, PARTICIPATING);
         List<Member> members = getParticipantsExcludingReviewer(reviewer, accompanies);
 
         return members.stream().map(MemberInfoDto::from).collect(Collectors.toList());

--- a/src/main/java/com/example/gotogetherbe/comment/service/CommentService.java
+++ b/src/main/java/com/example/gotogetherbe/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package com.example.gotogetherbe.comment.service;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.COMMENT_NOT_FOUND;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.POST_NOT_FOUND;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.USER_NOT_FOUND;
+import static com.example.gotogetherbe.notification.type.NotificationType.*;
 
 import com.example.gotogetherbe.comment.dto.CommentDto;
 import com.example.gotogetherbe.comment.dto.CommentRequest;
@@ -12,6 +13,8 @@ import com.example.gotogetherbe.global.exception.GlobalException;
 import com.example.gotogetherbe.global.exception.type.ErrorCode;
 import com.example.gotogetherbe.member.entitiy.Member;
 import com.example.gotogetherbe.member.repository.MemberRepository;
+import com.example.gotogetherbe.notification.service.EventPublishService;
+import com.example.gotogetherbe.notification.type.NotificationType;
 import com.example.gotogetherbe.post.entity.Post;
 import com.example.gotogetherbe.post.repository.PostRepository;
 import java.util.List;
@@ -26,6 +29,7 @@ public class CommentService {
   private final MemberRepository memberRepository;
   private final PostRepository postRepository;
   private final CommentRepository commentRepository;
+  private final EventPublishService eventPublishService;
 
   /**
    * 댓글 생성
@@ -44,6 +48,9 @@ public class CommentService {
             .post(post)
             .content(request.getContent())
             .build());
+
+    Member postAuthor = getMemberOrThrowById(post.getMember().getId());
+    eventPublishService.publishEvent(postId, postAuthor, COMMENT);
 
     return CommentDto.from(comment);
   }
@@ -102,6 +109,11 @@ public class CommentService {
 
   private Member getMemberOrThrow(String email) {
     return memberRepository.findByEmail(email)
+        .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+  }
+
+  private Member getMemberOrThrowById(Long memberId) {
+    return memberRepository.findById(memberId)
         .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
   }
 

--- a/src/main/java/com/example/gotogetherbe/comment/service/CommentService.java
+++ b/src/main/java/com/example/gotogetherbe/comment/service/CommentService.java
@@ -3,7 +3,7 @@ package com.example.gotogetherbe.comment.service;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.COMMENT_NOT_FOUND;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.POST_NOT_FOUND;
 import static com.example.gotogetherbe.global.exception.type.ErrorCode.USER_NOT_FOUND;
-import static com.example.gotogetherbe.notification.type.NotificationType.*;
+import static com.example.gotogetherbe.notification.type.NotificationType.COMMENT;
 
 import com.example.gotogetherbe.comment.dto.CommentDto;
 import com.example.gotogetherbe.comment.dto.CommentRequest;
@@ -14,7 +14,6 @@ import com.example.gotogetherbe.global.exception.type.ErrorCode;
 import com.example.gotogetherbe.member.entitiy.Member;
 import com.example.gotogetherbe.member.repository.MemberRepository;
 import com.example.gotogetherbe.notification.service.EventPublishService;
-import com.example.gotogetherbe.notification.type.NotificationType;
 import com.example.gotogetherbe.post.entity.Post;
 import com.example.gotogetherbe.post.repository.PostRepository;
 import java.util.List;

--- a/src/main/java/com/example/gotogetherbe/comment/service/CommentService.java
+++ b/src/main/java/com/example/gotogetherbe/comment/service/CommentService.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +39,7 @@ public class CommentService {
    * @param request    생성할 댓글 내용
    * @return 생성된 댓글의 정보를 포함한 CommentDto 객체
    */
+  @Transactional
   public CommentDto createComment(String email, Long postId, CommentRequest request) {
     Member member = getMemberOrThrow(email);
     Post post = getPostOrThrow(postId);

--- a/src/main/java/com/example/gotogetherbe/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/gotogetherbe/notification/controller/NotificationController.java
@@ -39,8 +39,7 @@ public class NotificationController {
 
     // 알림 확인
     @PostMapping("/{notificationId}")
-    public ResponseEntity<String> readNotification(@PathVariable Long notificationId) {
+    public void readNotification(@PathVariable Long notificationId) {
         notificationService.readNotification(notificationId);
-        return ResponseEntity.ok(notificationService.readNotification(notificationId));
     }
 }

--- a/src/main/java/com/example/gotogetherbe/notification/dto/NotificationDto.java
+++ b/src/main/java/com/example/gotogetherbe/notification/dto/NotificationDto.java
@@ -25,8 +25,6 @@ public class NotificationDto {
 
     private NotificationStatus status;
 
-    private String url;
-
     private LocalDateTime createdAt;
 
     public static NotificationDto from(Notification notification) {
@@ -36,7 +34,6 @@ public class NotificationDto {
             .memberId(notification.getMember().getId())
             .type(notification.getType())
             .status(notification.getStatus())
-            .url(notification.getUrl())
             .createdAt(notification.getCreatedAt())
             .build();
     }

--- a/src/main/java/com/example/gotogetherbe/notification/dto/NotificationInfoDto.java
+++ b/src/main/java/com/example/gotogetherbe/notification/dto/NotificationInfoDto.java
@@ -23,15 +23,12 @@ public class NotificationInfoDto {
 
     private NotificationStatus status;
 
-    private String url;
-
     public Notification of() {
         return Notification.builder()
             .member(this.member)
             .type(this.type)
             .postId(this.postId)
             .status(this.status)
-            .url(this.url)
             .build();
     }
 

--- a/src/main/java/com/example/gotogetherbe/notification/entity/Notification.java
+++ b/src/main/java/com/example/gotogetherbe/notification/entity/Notification.java
@@ -48,8 +48,6 @@ public class Notification {
     @Enumerated(EnumType.STRING)
     private NotificationStatus status;
 
-    private String url;
-
     @CreatedDate
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/example/gotogetherbe/notification/entity/Notification.java
+++ b/src/main/java/com/example/gotogetherbe/notification/entity/Notification.java
@@ -1,8 +1,8 @@
 package com.example.gotogetherbe.notification.entity;
 
 import com.example.gotogetherbe.member.entitiy.Member;
-import com.example.gotogetherbe.notification.type.NotificationType;
 import com.example.gotogetherbe.notification.type.NotificationStatus;
+import com.example.gotogetherbe.notification.type.NotificationType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -19,7 +19,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 

--- a/src/main/java/com/example/gotogetherbe/notification/service/EventPublishService.java
+++ b/src/main/java/com/example/gotogetherbe/notification/service/EventPublishService.java
@@ -1,12 +1,10 @@
 package com.example.gotogetherbe.notification.service;
 
-import static com.example.gotogetherbe.notification.type.NotificationStatus.*;
+import static com.example.gotogetherbe.notification.type.NotificationStatus.UNREAD;
 
 import com.example.gotogetherbe.member.entitiy.Member;
 import com.example.gotogetherbe.notification.dto.NotificationInfoDto;
-import com.example.gotogetherbe.notification.type.NotificationStatus;
 import com.example.gotogetherbe.notification.type.NotificationType;
-import com.example.gotogetherbe.post.entity.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/gotogetherbe/notification/service/EventPublishService.java
+++ b/src/main/java/com/example/gotogetherbe/notification/service/EventPublishService.java
@@ -1,0 +1,30 @@
+package com.example.gotogetherbe.notification.service;
+
+import static com.example.gotogetherbe.notification.type.NotificationStatus.*;
+
+import com.example.gotogetherbe.member.entitiy.Member;
+import com.example.gotogetherbe.notification.dto.NotificationInfoDto;
+import com.example.gotogetherbe.notification.type.NotificationStatus;
+import com.example.gotogetherbe.notification.type.NotificationType;
+import com.example.gotogetherbe.post.entity.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EventPublishService {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void publishEvent(Long postId, Member member, NotificationType type) {
+        NotificationInfoDto event = NotificationInfoDto.builder()
+            .member(member)
+            .postId(postId)
+            .status(UNREAD)
+            .type(type)
+            .build();
+
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/com/example/gotogetherbe/notification/service/NotificationService.java
+++ b/src/main/java/com/example/gotogetherbe/notification/service/NotificationService.java
@@ -97,8 +97,7 @@ public class NotificationService {
     /**
      * 알림 확인, 상태 변경(unread -> read)
      * @param notificationId 알림 id
-     * @return 알림 확인 시 이동할 url
-     */
+     * */
     public void readNotification(Long notificationId) {
         Notification notification = notificationRepository.findById(notificationId)
             .orElseThrow(() -> new GlobalException(NOTIFICATION_NOT_FOUND));

--- a/src/main/java/com/example/gotogetherbe/notification/service/NotificationService.java
+++ b/src/main/java/com/example/gotogetherbe/notification/service/NotificationService.java
@@ -16,7 +16,6 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Slf4j

--- a/src/main/java/com/example/gotogetherbe/notification/service/NotificationService.java
+++ b/src/main/java/com/example/gotogetherbe/notification/service/NotificationService.java
@@ -61,11 +61,10 @@ public class NotificationService {
      * @param notificationInfo 알림 정보
      */
     public void send(NotificationInfoDto notificationInfo) {
-        Notification notification = notificationRepository.save(
-            notificationInfo.of()); //repository에 저장
+        Notification notification = notificationRepository.save(notificationInfo.of()); //repository에 저장
         log.info("알림 저장 완료");
 
-        if (!notification.getMember().getAlarmStatus()) { // 알림 설정이 꺼져있으면 전송하지 않음
+        if (!notificationInfo.getMember().getAlarmStatus()) { // 알림 설정이 꺼져있으면 전송하지 않음
             return;
         }
 

--- a/src/main/java/com/example/gotogetherbe/notification/service/NotificationService.java
+++ b/src/main/java/com/example/gotogetherbe/notification/service/NotificationService.java
@@ -100,15 +100,12 @@ public class NotificationService {
      * @param notificationId 알림 id
      * @return 알림 확인 시 이동할 url
      */
-    @Transactional
-    public String readNotification(Long notificationId) {
+    public void readNotification(Long notificationId) {
         Notification notification = notificationRepository.findById(notificationId)
             .orElseThrow(() -> new GlobalException(NOTIFICATION_NOT_FOUND));
 
         notification.updateStatus(READ);
         notificationRepository.save(notification);
-
-        return notification.getUrl();
     }
 
     /**

--- a/src/main/java/com/example/gotogetherbe/post/entity/Post.java
+++ b/src/main/java/com/example/gotogetherbe/post/entity/Post.java
@@ -116,4 +116,8 @@ public class Post extends BaseEntity {
         this.currentPeople++;
     }
 
+    public void updateRecruitmentStatus(PostRecruitmentStatus status) {
+        this.recruitmentStatus = status;
+    }
+
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 현재 모집 인원과 최대 인원이 동떨어져 있어 비교 관리가 이루어지지 않음
- 알림 entity에 url 정보 포함
- 알림 on / off 반영되지 않음

**TO-BE**
- 현재 모집 인원(current_people)이 최대 인원(recruits_people)과 같아졌을 때, 모집 상태(recruitment_status)를 RECRUITMENT_COMPLETED로 변경하는 로직을 추가하여 더이상 동행 요청을 받지 않도록 함
- front와 이야기 후(Notification의 type에 따라 처리하기로 함) url 정보는 없어도 될 거 같다는 결론이 도출되어 제거함
- Notification 저장 후, 사용자의 알림 상태(alarm_status)에 따라 실시간 알림을 전송 여부를 정하는 로직을 수정함
- 동행 요청, 승인, 거절, 댓글 작성, 리뷰 작성 알림 이벤트 발행 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 