### PR TITLE
[feat] 회원 탈퇴, 회원 알람 정보 조회,수정 기능 구현

### DIFF
--- a/src/main/java/com/example/gotogetherbe/member/controller/MemberController.java
+++ b/src/main/java/com/example/gotogetherbe/member/controller/MemberController.java
@@ -7,9 +7,11 @@ import com.example.gotogetherbe.member.dto.MemberResponse;
 import com.example.gotogetherbe.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,7 +36,7 @@ public class MemberController {
   @PutMapping(path = "/myProfile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE
   ,produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<MemberResponse> updateMyProfile(@RequestPart(name = "request", required = false)
-  @Valid @RequestBody MemberRequest request,
+  @Valid MemberRequest request,
       @LoginUser String username,
       @RequestPart(name = "image", required = false)MultipartFile profileImage){
     return ResponseEntity.ok(memberService.updateMyProfileInfo(request,username, profileImage));
@@ -44,5 +46,21 @@ public class MemberController {
   public ResponseEntity<MemberResponse> getProfile(@RequestParam("memberId") Long id){
     return ResponseEntity.ok(memberService.getMemberInfo(id));
   }
+
+  @PatchMapping("/withdraw")
+  public ResponseEntity<?> withdraw(@LoginUser String username){
+    memberService.withdraw(username);
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
+  @GetMapping("/alarm")
+  public ResponseEntity<?> getNotificationSetting(@LoginUser String username){
+    return ResponseEntity.ok(memberService.checkAlarmStatus(username));
+  }
+  @PatchMapping("/alarm")
+  public ResponseEntity<?> changeNotificationSetting(@LoginUser String username){
+    memberService.changeAlarmStatus(username);
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
+
 
 }

--- a/src/main/java/com/example/gotogetherbe/member/entitiy/Member.java
+++ b/src/main/java/com/example/gotogetherbe/member/entitiy/Member.java
@@ -6,6 +6,7 @@ import com.example.gotogetherbe.member.entitiy.type.MemberGender;
 import com.example.gotogetherbe.member.entitiy.type.MemberLoginType;
 import com.example.gotogetherbe.member.entitiy.type.MemberMbti;
 import com.example.gotogetherbe.member.entitiy.type.MemberRoleType;
+import com.example.gotogetherbe.member.entitiy.type.MemberStatus;
 import com.example.gotogetherbe.post.entity.Post;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -19,6 +20,7 @@ import jakarta.persistence.Id;
 
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.PostPersist;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -91,16 +93,43 @@ public class Member extends BaseEntity {
   @Builder.Default
   private boolean emailAuth = false;
 
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  private MemberStatus status = MemberStatus.ACTIVE;
+
   @Builder.Default
   @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Post> posts = new ArrayList<>();
 
 
-  @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+  @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true,
+      fetch = FetchType.LAZY)
   private MemberAssessment memberAssessment;
+  @PostPersist
+  public void initializeMemberAssessment() {
+    this.memberAssessment = MemberAssessment.builder()
+        .member(this)
+        .totalReviewCount(0)
+        .rating(0.0)
+        .punctualityCount(0L)
+        .responsivenessCount(0L)
+        .photographyCount(0L)
+        .mannerCount(0L)
+        .navigationCount(0L)
+        .humorCount(0L)
+        .adaptabilityCount(0L)
+        .build();
+  }
 
   public void changeEmailAuth() {
     this.emailAuth = true;
+  }
+
+  public void changeAlarmStatus() {
+    this.alarmStatus = !this.alarmStatus;
+  }
+  public void changeStatus(MemberStatus status) {
+    this.status = status;
   }
 
   public void addPost(Post post){

--- a/src/main/java/com/example/gotogetherbe/member/entitiy/type/MemberStatus.java
+++ b/src/main/java/com/example/gotogetherbe/member/entitiy/type/MemberStatus.java
@@ -1,0 +1,12 @@
+package com.example.gotogetherbe.member.entitiy.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberStatus {
+  ACTIVE,
+  INACTIVE,
+  DELETED
+}

--- a/src/main/java/com/example/gotogetherbe/member/service/MemberService.java
+++ b/src/main/java/com/example/gotogetherbe/member/service/MemberService.java
@@ -8,6 +8,7 @@ import com.example.gotogetherbe.global.util.aws.service.AwsS3Service;
 import com.example.gotogetherbe.member.dto.MemberRequest;
 import com.example.gotogetherbe.member.dto.MemberResponse;
 import com.example.gotogetherbe.member.entitiy.Member;
+import com.example.gotogetherbe.member.entitiy.type.MemberStatus;
 import com.example.gotogetherbe.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -81,6 +82,26 @@ public class MemberService {
     awsS3Service.uploadToS3(multipartFile, fileName);
 
     return awsS3Service.getUrl(fileName);
+  }
+
+  @Transactional
+  public void withdraw(String username){
+    Member member = memberRepository.findByEmail(username)
+        .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+    member.changeStatus(MemberStatus.DELETED);
+  }
+
+  @Transactional
+  public void changeAlarmStatus(String username){
+    Member member = memberRepository.findByEmail(username)
+        .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+    member.changeAlarmStatus();
+  }
+
+  public boolean checkAlarmStatus(String username){
+    Member member = memberRepository.findByEmail(username)
+        .orElseThrow(() -> new GlobalException(USER_NOT_FOUND));
+    return member.getAlarmStatus();
   }
 
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- 회원 탈퇴 기능
  - 회원 탈퇴를 하면 Member 테이블의 status = DELETED 로 변경
- 회원 알람 정보 조회, 수정 기능
  - 회원 알람을 정보 Member 테이블의 alarmStatus 조회 또는 on/off 설정가능
  - Default = false
  
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 